### PR TITLE
fix: update NLTK to 3.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 chardet==7.4.3
 EbookLib==0.20
 langdetect==1.0.9
-nltk==3.9.4
+nltk==3.10.0
 beautifulsoup4==4.14.3
 gradio==6.13.0
 xmltodict==1.0.4


### PR DESCRIPTION
## Summary

Update the pinned NLTK dependency from 3.9.4 to 3.10.0.

## Why

NLTK 3.9.4 is in the affected range for several GitHub-reviewed advisories fixed in 3.10.0:

- [CVE-2026-12075 / GHSA-qvv7-cg9c-w4x3](https://github.com/advisories/GHSA-qvv7-cg9c-w4x3)
- [CVE-2026-12061 / GHSA-fg7f-2386-8897](https://github.com/advisories/GHSA-fg7f-2386-8897)
- [CVE-2026-12072 / GHSA-6hm5-jgcp-p838](https://github.com/advisories/GHSA-6hm5-jgcp-p838)
- [CVE-2026-12074 / GHSA-xh95-f55m-82fw](https://github.com/advisories/GHSA-xh95-f55m-82fw)

The application directly uses `nltk.download()` and `nltk.sent_tokenize()`.

## Impact

The existing NLTK call sites remain unchanged; only the patched dependency version is selected.

## Validation

- compiled `dodari.py` without writing bytecode
- downloaded `punkt_tab` with NLTK 3.10.0
- verified `nltk.sent_tokenize()` with a two-sentence smoke test
- `git diff --check`
